### PR TITLE
align API with OriginOS UI

### DIFF
--- a/types.go
+++ b/types.go
@@ -60,7 +60,7 @@ func tierFree() sub_benefits {
 		Max_Login_History:       10,
 		Max_Rmails:              100,
 		FileSystem_Size:         5_000_000,
-		Bio_Length:              300,
+		Bio_Length:              200,
 		Max_Transaction_History: 20,
 		Daily_Credit_Multipler:  1,
 	}


### PR DESCRIPTION
OriginOS displays and enforces a 200-char bio limit, but the API constant was still set to 300, causing a mismatch between what users see and what the backend allows.

Updated the variable from 300 → 200 so the API matches the UI and platform behavior.